### PR TITLE
Update Beam and Flink versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Beam + Flink Runner (Python Examples)
 
+These examples target Apache Beam 2.62.0 running on Apache Flink 1.17.2 with Python 3.12.
+The sample pipeline counts words from a small in-memory data set and prints the results.
+
 
 There are very few documentation on how to run Apache Beam with Flink Runner, especially for how to configure the setup. As a result, I'd like to provide an example on how we set up our infrastructure.
 
@@ -9,7 +12,7 @@ The example contains 2 approaches:
   please ensure you have the official flink operator installed on your kubernetes cluster in order to run this.
 
 - Docker Compose:
-  please ensure you have docker-compose installed
+  a `docker-compose.yaml` is provided to start a local Flink cluster with the web UI (port 8081) and endpoints for submitting Beam code; please ensure you have docker-compose installed
 
 
 In our use cases, the kubernetes is used for production, the docker-compose is for local testing/development.
@@ -30,7 +33,6 @@ docker-compose -f docker-compose.yaml up [-d]
 2.  Trigger the app
 ```
 python example.py \
-  --topic test --group test-group --bootstrap-server host.docker.internal:9092 \
   --job_endpoint host.docker.internal:8099 \
   --artifact_endpoint host.docker.internal:8098 \
   --environment_type=EXTERNAL \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,4 @@
+# Docker Compose stack for Flink with Beam Python support
 version: '3'
 services:
   jobmanager:
@@ -16,7 +17,6 @@ services:
     build:
       context: docker
       dockerfile: Dockerfile
-    scale: 1
     depends_on:
       - jobmanager
     command: ['taskmanager']

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM  --platform=linux/amd64 flink:1.15.4-java8
+FROM  --platform=linux/amd64 flink:1.17.2-scala_2.12-java11
 
 USER root
 
@@ -7,17 +7,17 @@ RUN add-apt-repository ppa:deadsnakes/ppa -y
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
         build-essential \
-        python3.9-dev \
-        python3.9-venv \
+        python3.12-dev \
+        python3.12-venv \
         curl \
     && \
     apt-get clean
 
 # install java SDK
-COPY --from=apache/beam_java8_sdk:2.41.0 /opt/apache/beam/ /opt/apache/beam_java/
+COPY --from=apache/beam_java11_sdk:2.62.0 /opt/apache/beam/ /opt/apache/beam_java/
 
 # install python SDK
-COPY --from=apache/beam_python3.9_sdk:2.41.0 /opt/apache/beam/ /opt/apache/beam/
+COPY --from=apache/beam_python3.12_sdk:2.62.0 /opt/apache/beam/ /opt/apache/beam/
 
 RUN mv /opt/apache/beam_java/boot /opt/apache/beam/java_boot && \
     cp -r /opt/apache/beam_java/* /opt/apache/beam/
@@ -26,10 +26,10 @@ RUN mv /opt/apache/beam_java/boot /opt/apache/beam/java_boot && \
 COPY requirements.txt docker-entrypoint.sh install-flink.sh /
 ENV PATH=/opt/venv/bin:/opt/flink/bin:$PATH \
     FLINK_HOME=/opt/flink \
-    JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
-RUN FLINK_VERSION=1.15.4 BEAM_VERSION=2.41.0 /install-flink.sh
-RUN python3.9 -m venv /opt/venv && \
+RUN FLINK_VERSION=1.17.2 BEAM_VERSION=2.62.0 /install-flink.sh
+RUN python3.12 -m venv /opt/venv && \
     /opt/venv/bin/pip install pip -U && \
     /opt/venv/bin/pip install -r /requirements.txt
 

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,1 +1,1 @@
-apache_beam==2.41.0
+apache_beam==2.62.0

--- a/docker/src/example.py
+++ b/docker/src/example.py
@@ -1,12 +1,10 @@
 from __future__ import absolute_import
 
-import argparse
-import logging
 import os
+import re
 import sys
 
 import apache_beam as beam
-from apache_beam.io.kafka import ReadFromKafka, default_io_expansion_service
 from apache_beam.options.pipeline_options import PipelineOptions
 
 
@@ -14,48 +12,24 @@ def run_pipeline():
     args = [
         "--streaming",
         "--runner=PortableRunner",
-        f"--job_name={os.getenv('FLINK_JOB_NAME', 'test-app')}",
+        f"--job_name={os.getenv('FLINK_JOB_NAME', 'wordcount')}",
     ]
     args.extend(sys.argv[1:])
 
-    arg_parser = argparse.ArgumentParser(
-        add_help=True,
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
-    )
-    arg_parser.add_argument('--topic')
-    arg_parser.add_argument('--group')
-    arg_parser.add_argument('--bootstrap-server')
-
-    options, pipeline_args = arg_parser.parse_known_args(args)
-
-    with beam.Pipeline(options=PipelineOptions(pipeline_args)) as pipeline:
-        print(f"pipeline_args: {pipeline_args}")
-        topic = options.topic
-        print(f"Using topic: {topic}")
+    with beam.Pipeline(options=PipelineOptions(args)) as pipeline:
+        lines = pipeline | "Create" >> beam.Create(
+            [
+                "to be or not to be",
+                "that is the question",
+            ]
+        )
         (
-            pipeline
-            | f"Read from kafka topic {topic}" >> ReadFromKafka(
-                consumer_config={
-                    "bootstrap.servers": options.bootstrap_server,
-                    'auto.offset.reset': 'earliest',
-                    'enable.auto.commit': 'false',
-                    'group.id': options.group,
-                },
-                topics=topic,
-                with_metadata=False,
-                expansion_service=default_io_expansion_service(
-                    # without the append args, it will keep trying to launch as a
-                    # Docker container which is incompatible in K8s
-                    append_args=[
-                        '--defaultEnvironmentType=PROCESS',
-                        '--defaultEnvironmentConfig={"command":"/opt/apache/beam/java_boot"}',
-                        # without using the deprecated read, it will failed failrly quickly
-                        '--experiments=use_deprecated_read',
-                    ]
-                ),
-                commit_offset_in_finalize=True
-            )
-            | "logging" >> beam.Map(lambda x: logging.info(f"logged: {x}"))
+            lines
+            | "Split" >> beam.FlatMap(lambda line: re.findall(r"[A-Za-z']+", line.lower()))
+            | "PairWithOne" >> beam.Map(lambda word: (word, 1))
+            | "GroupAndSum" >> beam.CombinePerKey(sum)
+            | "Format" >> beam.Map(lambda kv: f"{kv[0]}: {kv[1]}")
+            | "Print" >> beam.Map(print)
         )
 
 

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -33,7 +33,7 @@ metadata:
 spec:
   image: example_image:v1.0
   imagePullPolicy: IfNotPresent
-  flinkVersion: v1_15
+  flinkVersion: v1_17
   flinkConfiguration:
     kubernetes.entry.path: "/docker-entrypoint.sh"
     taskmanager.numberOfTaskSlots: "4"
@@ -76,7 +76,7 @@ spec:
           args: ["/opt/apache/beam/boot", "--worker_pool"]
           env:
             - name: JAVA_HOME
-              value: /usr/lib/jvm/java-8-openjdk-amd64
+              value: /usr/lib/jvm/java-11-openjdk-amd64
             - name: FLINK_JOB_NAME
               value: example-app
           volumeMounts:
@@ -105,7 +105,7 @@ spec:
           - name: FLINK_HOME
             value: /opt/flink
           - name: JAVA_HOME
-            value: /usr/lib/jvm/java-8-openjdk-amd64
+            value: /usr/lib/jvm/java-11-openjdk-amd64
           - name: FLINK_JOB_NAME
             value: example-app
         volumeMounts:


### PR DESCRIPTION
## Summary
- target Apache Beam 2.62.0 on Flink 1.17.2
- upgrade Docker and Compose configs to Python 3.12
- replace Kafka sample with in-memory word count example

## Testing
- `python -m py_compile docker/src/example.py docker/src/no_xlang_example.py`
- `docker compose config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68ad09cd46048326a29d68a8835fb93f