### PR TITLE
Add loopback docker compose and expose ports

### DIFF
--- a/docker-compose-loopback.yaml
+++ b/docker-compose-loopback.yaml
@@ -1,0 +1,46 @@
+version: '3'
+services:
+  jobmanager:
+    build:
+      context: docker
+      dockerfile: Dockerfile
+    command: ['jobmanager']
+    ports:
+      - "8081:8081"
+    environment:
+      FLINK_PROPERTIES: "jobmanager.rpc.address: jobmanager\nparallelism.default: 1"
+      FLINK_JOB_NAME: 'test'
+    volumes:
+      - artifacts:/tmp/beam-artifact-staging
+  taskmanager:
+    build:
+      context: docker
+      dockerfile: Dockerfile
+    depends_on:
+      - jobmanager
+    command: ['taskmanager']
+    environment:
+      FLINK_PROPERTIES: "jobmanager.rpc.address: jobmanager\ntaskmanager.numberOfTaskSlots: 1\nparallelism.default: 1"
+    volumes:
+      - artifacts:/tmp/beam-artifact-staging
+  beam-jobserver:
+    build:
+      context: docker
+      dockerfile: Dockerfile
+    entrypoint:
+      - java
+      - -cp
+      - /opt/flink/flink-web-upload/beam-runner.jar
+      - org.apache.beam.runners.flink.FlinkJobServerDriver
+      - --flink-master=jobmanager
+      - --job-host=beam-jobserver
+    ports:
+      - "8097:8097"
+      - "8098:8098"
+      - "8099:8099"
+    depends_on:
+      - jobmanager
+    volumes:
+      - artifacts:/tmp/beam-artifact-staging
+volumes:
+  artifacts:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,41 +1,42 @@
-FROM  --platform=linux/amd64 flink:1.17.2-scala_2.12-java11
+FROM --platform=linux/amd64 flink:1.17.2-scala_2.12-java11
 
 USER root
 
-RUN rm -rf /var/lib/apt/lists/* && \
-    apt-get update && \
+# Install system packages and Python 3.12
+RUN apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common && \
     add-apt-repository ppa:deadsnakes/ppa -y && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         build-essential \
+        python3.12 \
         python3.12-dev \
         python3.12-venv \
         curl && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-
-# install java SDK
-COPY --from=apache/beam_java11_sdk:2.62.0 /opt/apache/beam/ /opt/apache/beam_java/
-
-# install python SDK
-COPY --from=apache/beam_python3.12_sdk:2.62.0 /opt/apache/beam/ /opt/apache/beam/
-
-RUN mv /opt/apache/beam_java/boot /opt/apache/beam/java_boot && \
-    cp -r /opt/apache/beam_java/* /opt/apache/beam/
-
-
-COPY requirements.txt docker-entrypoint.sh install-flink.sh /
+ARG BEAM_VERSION=2.62.0
+ARG FLINK_VERSION=1.17.2
 ENV PATH=/opt/venv/bin:/opt/flink/bin:$PATH \
     FLINK_HOME=/opt/flink \
-    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+    JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64 \
+    BEAM_VERSION=${BEAM_VERSION} \
+    FLINK_VERSION=${FLINK_VERSION}
 
-RUN FLINK_VERSION=1.17.2 BEAM_VERSION=2.62.0 /install-flink.sh
-RUN python3.12 -m venv /opt/venv && \
-    /opt/venv/bin/pip install pip -U && \
-    /opt/venv/bin/pip install -r /requirements.txt
+# Install Beam Python SDK and Flink job server artifacts
+COPY requirements.txt docker-entrypoint.sh install-flink.sh /
+RUN chmod +x /install-flink.sh /docker-entrypoint.sh && \
+    /install-flink.sh && \
+    python3.12 -m venv /opt/venv && \
+    /opt/venv/bin/pip install --no-cache-dir -U pip && \
+    /opt/venv/bin/pip install --no-cache-dir apache-beam[gcp]==${BEAM_VERSION} && \
+    /opt/venv/bin/pip install --no-cache-dir -r /requirements.txt && \
+    rm /requirements.txt /install-flink.sh
 
 COPY src/ /src
 WORKDIR /src
 
-ENTRYPOINT [ "/docker-entrypoint.sh" ]
+# Expose Flink web UI and Beam job server ports for loopback execution
+EXPOSE 8081 8097 8098 8099
+
+ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- add docker-compose config using Beam's loopback environment
- expose web and job server ports in Dockerfile
- refactor Dockerfile to install Beam SDK via pip and run Flink job server setup

## Testing
- `python -m py_compile docker/src/example.py docker/src/no_xlang_example.py`
- `docker build -t beam-loopback-test -f docker/Dockerfile docker` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad193bf4448326bc961c02eb33755d